### PR TITLE
Check that output file exists before opening

### DIFF
--- a/action.py
+++ b/action.py
@@ -135,15 +135,17 @@ if status.returncode == 0:
 else:
     _summary("❌ pip-audit found one or more problems")
 
-    with open("/tmp/pip-audit-output.txt", "r") as io:
-        output = io.read()
+    p = Path("/tmp/pip-audit-output.txt")
+    if p.exists():
+        with p.open() as io:
+            output = io.read()
 
-        # This is really nasty: our output contains multiple lines,
-        # so we can't naively stuff it into an output.
-        print(f"output={b64encode(output.encode()).decode()}", file=_GITHUB_OUTPUT)
+            # This is really nasty: our output contains multiple lines,
+            # so we can't naively stuff it into an output.
+            print(f"output={b64encode(output.encode()).decode()}", file=_GITHUB_OUTPUT)
 
-        _log(output)
-        _summary(output)
+            _log(output)
+            _summary(output)
 
 
 _log(status.stdout)


### PR DESCRIPTION
The action crashes when pip-audit exits without writing anything to `/tmp/pip-audit-output.txt`. We now check that the file exists before opening it, which should allow the action to run to completion and write the pip-audit `stderr` to the summary. This is a quick band-aid to fix the immediate crash, maybe in the future we will want special diagnostics in the summary for when there is no pip-audit output?