### PR TITLE
requirements: constrain requests below 2.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip-audit ~= 2.0, >= 2.4.13
 
 # See: https://github.com/psf/requests/issues/6437
-requests == 2.29.*
+requests < 2.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 pip-audit ~= 2.0, >= 2.4.13
+
+# See: https://github.com/psf/requests/issues/6437
+requests == 2.29.*


### PR DESCRIPTION
This is a temporary fix; `pip-audit` itself should also constrain this version.

Fixes #38.

See psf/requests#6437.