### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         id: pip-audit
         with:
@@ -37,7 +37,7 @@ jobs:
   selftest-environment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make the environment vulnerable
         run: |
           python -m pip install --no-deps --requirement ./test/vulnerable.txt
@@ -59,7 +59,7 @@ jobs:
         local: [true, false]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: make a virtual environment vulnerable
         run: |
           python -m venv env
@@ -82,7 +82,7 @@ jobs:
   selftest-pyproject:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         id: pip-audit
         with:
@@ -100,7 +100,7 @@ jobs:
   selftest-pipaudit-fail:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         id: pip-audit
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,5 +18,5 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: semgrep ci

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
   selftest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install
         run: python -m pip install .
       - uses: pypa/gh-action-pip-audit@v1.1.0
@@ -42,7 +42,7 @@ jobs:
   selftest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install
         run: |
           python -m venv env/


### PR DESCRIPTION
This PR updates the used `actions/checkout` to `v4` (currently the newest available). It also updates the example workflows in the readme.

The changes in the `yml` files, could be easily handles by the dependabot. Should I create a PR configuring it for that? There are few more outdated dependencies.