### PR TITLE
Add support for --disable-pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,23 @@ Example
       PYSEC-AAAA-BBBBB
 ```
 
+### `disable-pip`
+
+**Default**: `false`
+
+The `disable-pip` setting disable the use of `pip` for dependency resolution. This can only be used with
+hashed requirements files or if the `no-deps` setting has been provided.
+
+Example
+
+```yaml
+- uses: pypa/gh-action-pip-audit@v1.1.0
+  with:
+    inputs: requirements.lock
+    disable-pip: true
+    no-deps: true
+```
+
 ### Internal options
 <details>
   <summary>⚠️ Internal options ⚠️</summary>

--- a/action.py
+++ b/action.py
@@ -82,6 +82,9 @@ if os.getenv("GHA_PIP_AUDIT_REQUIRE_HASHES", "false") != "false":
 if os.getenv("GHA_PIP_AUDIT_LOCAL", "false") != "false":
     pip_audit_args.append("--local")
 
+if os.getenv("GHA_PIP_DISABLE_PIP", "false") != "false":
+    pip_audit_args.append("--disable-pip")
+
 index_url = os.getenv("GHA_PIP_AUDIT_INDEX_URL")
 if index_url != "":
     pip_audit_args.extend(["--index-url", index_url])

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "vulnerabilities to explicitly exclude, if present (whitespace separated)"
     required: false
     default: ""
+  disable-pip:
+    description: "disable pip"
+    required: false
+    default: false
   internal-be-careful-allow-failure:
     description: "don't fail the job if the audit fails (default false)"
     required: false
@@ -82,6 +86,7 @@ runs:
         GHA_PIP_AUDIT_INDEX_URL: "${{ inputs.index-url }}"
         GHA_PIP_AUDIT_EXTRA_INDEX_URLS: "${{ inputs.extra-index-urls }}"
         GHA_PIP_AUDIT_IGNORE_VULNS: "${{ inputs.ignore-vulns }}"
+        GHA_PIP_DISABLE_PIP: "{{ inputs.disable-pip }}"
         GHA_PIP_AUDIT_INTERNAL_BE_CAREFUL_ALLOW_FAILURE: "${{ inputs.internal-be-careful-allow-failure }}"
         GHA_PIP_AUDIT_INTERNAL_BE_CAREFUL_EXTRA_FLAGS: "${{ inputs.internal-be-careful-extra-flags }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         GHA_PIP_AUDIT_INDEX_URL: "${{ inputs.index-url }}"
         GHA_PIP_AUDIT_EXTRA_INDEX_URLS: "${{ inputs.extra-index-urls }}"
         GHA_PIP_AUDIT_IGNORE_VULNS: "${{ inputs.ignore-vulns }}"
-        GHA_PIP_DISABLE_PIP: "{{ inputs.disable-pip }}"
+        GHA_PIP_DISABLE_PIP: "${{ inputs.disable-pip }}"
         GHA_PIP_AUDIT_INTERNAL_BE_CAREFUL_ALLOW_FAILURE: "${{ inputs.internal-be-careful-allow-failure }}"
         GHA_PIP_AUDIT_INTERNAL_BE_CAREFUL_EXTRA_FLAGS: "${{ inputs.internal-be-careful-extra-flags }}"
       shell: bash


### PR DESCRIPTION
Adding support for the `disable-pip` parameter.

We are working on a project made with `rye` and have a specific `requirements.lock` file. Via command line, we were able to perform the assessment via `pip-audit --disable-pip --requirement requirements.lock --no-deps` but the GH action lacks the `--disable-pip` flag.

This PR intents do add such support.

It has been successfully tested on an private project.

Powered by TheAgileMonkeys team.